### PR TITLE
remove references to expired domain

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "AlienTube",
   "description": "Reddit Comments for YouTube",
   "author": "Delexious",
-  "homepage_url": "http://alientube.co/",
+  "homepage_url": "https://github.com/KoffeinFlummi/alientube",
   "version": "2.7",
   "icons": { "16": "icon16.png",
            "48": "icon48.png",
@@ -16,7 +16,7 @@
 
   "content_scripts": [
     {
-      "matches": ["*://www.youtube.com/*", "*://vimeo.com/*", "*://alientube.co/"],
+      "matches": ["*://www.youtube.com/*", "*://vimeo.com/*"],
       "js": ["js/snuownd.js", "js/script.js"],
       "css": ["res/style.css"],
       "run_at": "document_start"
@@ -26,7 +26,6 @@
     "http://www.youtube.com/",
     "https://www.youtube.com/",
     "https://api.reddit.com/",
-    "http://alientube.co/",
     "storage"
   ],
   

--- a/Firefox/lib/main.js
+++ b/Firefox/lib/main.js
@@ -27,7 +27,7 @@ preferences.keys("extensions." + addonid).forEach(function(key) {
 });
 
 pageMod.PageMod({
-    include: ["https://www.youtube.com/*", "http://www.youtube.com/*", "http://alientube.co/"],
+    include: ["https://www.youtube.com/*", "http://www.youtube.com/*"],
     contentScriptOptions : contentScriptData,
     contentStyleFile: [
         data.url('style.css')

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 alientube
 =========
 
-A Chrome, Firefox and Safari extension that embeds Reddit comments, in your YouTube!  
-[http://alientube.co/](http://alientube.co/)
+A Chrome, Firefox and Safari extension that embeds Reddit comments, in your YouTube!
+[https://github.com/KoffeinFlummi/alientube](https://github.com/KoffeinFlummi/alientube)
 
 Instructions
 -------------
@@ -15,8 +15,3 @@ TODO
 
 
 ![Image of the extension in action](https://lh5.googleusercontent.com/PdAptwghLGNmtw_N93qkotTDMjYNbc-2vXadlWBSBr0QNLXOQ7__Ndkn9icmkDDgUkXw50fLOXs=s640-h400-e365-rw)
-     
-	     
-   
-   
-The Safari version of AlienTube is signed by and distributed under the name of Codeux Software, LLC to help with its availability. AlienTube is not maintained in anyway by this organization.

--- a/Safari.safariextension/Info.plist
+++ b/Safari.safariextension/Info.plist
@@ -38,7 +38,6 @@
 		<array>
 			<string>http://www.youtube.com/*</string>
 			<string>https://www.youtube.com/*</string>
-			<string>https://alientube.co/</string>
 		</array>
 	</dict>
 	<key>Description</key>
@@ -55,7 +54,6 @@
 			<array>
 				<string>www.youtube.com</string>
 				<string>api.reddit.com</string>
-				<string>alientube.co</string>
 			</array>
 			<key>Include Secure Pages</key>
 			<true/>
@@ -64,6 +62,6 @@
 		</dict>
 	</dict>
 	<key>Website</key>
-	<string>http://alientube.co/</string>
+        <string>https://github.com/KoffeinFlummi/alientube</string>
 </dict>
 </plist>

--- a/TypeScript/index.ts
+++ b/TypeScript/index.ts
@@ -31,11 +31,7 @@
 "use strict";
 function at_initialise() {
     if (window.top === window) {
-        if (window.location.host === "alientube.co") {
-            document.body.classList.add("installed");
-        } else {
-            new AlienTube.Application();
-        }
+        new AlienTube.Application();
     }
 }
 

--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -1,6 +1,6 @@
 {
   "api_header_message": {
-    "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (http://alientube.co/) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
+    "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (https://github.com/KoffeinFlummi/alientube) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
     "description": "Message that is sent with every request to Reddit so they can identify our requests and potentially contact us should any issues arise"
   },
   "timestamp_format_year": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
     "api_header_message": {
-        "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (http://alientube.co/) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
+        "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (https://github.com/KoffeinFlummi/alientube) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
         "description": "Message that is sent with every request to Reddit so they can identify our requests and potentially contact us should any issues arise"
     },
     "timestamp_format_year": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,6 +1,6 @@
 {
   "api_header_message": {
-    "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (http://alientube.co/) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
+    "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (https://github.com/KoffeinFlummi/alientube) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
     "description": "Message that is sent with every request to Reddit so they can identify our requests and potentially contact us should any issues arise"
   },
   "timestamp_format_year": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
     "api_header_message": {
-        "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (http://alientube.co/) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
+        "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (https://github.com/KoffeinFlummi/alientube) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
         "description": "Message that is sent with every request to Reddit so they can identify our requests and potentially contact us should any issues arise"
     },
     "timestamp_format_year": {

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -1,6 +1,6 @@
 {
   "api_header_message": {
-    "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (http://alientube.co/) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
+    "message": "Hello Reddit! This request was made by the AlienTube Browser Extension (https://github.com/KoffeinFlummi/alientube) If you have noticed unusual or overloading traffic here, you can contact the developer at alex@sorlie.co.uk",
     "description": "Message that is sent with every request to Reddit so they can identify our requests and potentially contact us should any issues arise"
   },
   "timestamp_format_year": {


### PR DESCRIPTION
The `alientube.co` domain used by the original extension expired. It seems to be serving malware and redirecting users to other unwanted sites, so it might be a good idea to remove any references to that site. This PR removes all of the references I was able to find.