### PR TITLE
Fix fail to load error by using uncredentialed GET when applicable (Fix #28, #25)

### DIFF
--- a/TypeScript/CommentSection.ts
+++ b/TypeScript/CommentSection.ts
@@ -129,7 +129,7 @@ module AlienTube {
                             }
                             this.returnNoResults();
                         }
-                    }.bind(this), null, loadingScreen);
+                    }.bind(this), null, loadingScreen, false);
                 }.bind(this));
             }
         }
@@ -169,7 +169,7 @@ module AlienTube {
 
                 new CommentThread(responseObject, this);
                 this.storedTabCollection.push(responseObject);
-            }.bind(this), null, loadingScreen);
+            }.bind(this), null, loadingScreen, false);
         }
 
         /**

--- a/TypeScript/HttpRequest.ts
+++ b/TypeScript/HttpRequest.ts
@@ -15,7 +15,7 @@ module AlienTube {
     export class HttpRequest {
         private static acceptableResponseTypes = [200, 201, 202, 301, 302, 303, 0];
 
-        constructor(url: string, type: RequestType, callback: any, postData?: any, errorHandler?: any) {
+        constructor(url: string, type: RequestType, callback: any, postData?: any, errorHandler?: any, useCredentials: boolean = true) {
              if (Utilities.getCurrentBrowser() === Browser.SAFARI && safari.self.addEventListener) {
                 /* Generate a unique identifier to identify our request and response through Safari's message system. */
                 let uuid = HttpRequest.generateUUID();
@@ -42,7 +42,7 @@ module AlienTube {
             } else {
                 let xhr = new XMLHttpRequest();
                 xhr.open(RequestType[type], url, true);
-                xhr.withCredentials = true;
+                xhr.withCredentials = useCredentials;
                 if (type === RequestType.POST) {
                     xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
                 }

--- a/TypeScript/RedditAPI/RedditRequest.ts
+++ b/TypeScript/RedditAPI/RedditRequest.ts
@@ -21,17 +21,19 @@ module AlienTube.Reddit {
         private postData: any;
         private loadingScreen: LoadingScreen;
         private attempts: number;
+        private useCredentials: boolean;
 
         private loadTimer = 0;
         private timeoutTimer = 0;
 
-        constructor(url: string, type: RequestType, callback: any, postData?: any, loadingScreen?: LoadingScreen) {
+        constructor(url: string, type: RequestType, callback: any, postData?: any, loadingScreen?: LoadingScreen, useCredentials?: boolean) {
             /* Move the request parameters so they are accessible from anywhere within the class. */
             this.requestUrl = url;
             this.requestType = type;
             this.finalCallback = callback;
             this.postData = postData;
             this.loadingScreen = loadingScreen;
+            this.useCredentials = useCredentials === undefined ? true : useCredentials;
             
             /* Perform the request. */
             this.performRequest();
@@ -57,7 +59,7 @@ module AlienTube.Reddit {
             }, 30000);
 
             /* Perform the reddit api request */
-            new HttpRequest(this.requestUrl, this.requestType, this.onSuccess.bind(this), this.postData, this.onRequestError.bind(this));
+            new HttpRequest(this.requestUrl, this.requestType, this.onSuccess.bind(this), this.postData, this.onRequestError.bind(this), this.useCredentials);
         }
     	
         /**

--- a/TypeScript/RedditAPI/RedditRequest.ts
+++ b/TypeScript/RedditAPI/RedditRequest.ts
@@ -26,14 +26,14 @@ module AlienTube.Reddit {
         private loadTimer = 0;
         private timeoutTimer = 0;
 
-        constructor(url: string, type: RequestType, callback: any, postData?: any, loadingScreen?: LoadingScreen, useCredentials?: boolean) {
+        constructor(url: string, type: RequestType, callback: any, postData?: any, loadingScreen?: LoadingScreen, useCredentials: boolean = true) {
             /* Move the request parameters so they are accessible from anywhere within the class. */
             this.requestUrl = url;
             this.requestType = type;
             this.finalCallback = callback;
             this.postData = postData;
             this.loadingScreen = loadingScreen;
-            this.useCredentials = useCredentials === undefined ? true : useCredentials;
+            this.useCredentials = useCredentials;
             
             /* Perform the request. */
             this.performRequest();


### PR DESCRIPTION
Reddit allows CORS on their unauthenticated API but all of our requests are `xhr.useCredentials = true`. This is not necessary for the getting of comments and threads, only votes. Since getting the comments is the most important feature for this extension, I simply added a parameter so we do not send credentials for these API requests. Further work will need to be done to support the authenticated API actions, but this should help for now.